### PR TITLE
feat: multipart code (:warning: POSSIBLE BREAKING)

### DIFF
--- a/template.go
+++ b/template.go
@@ -272,6 +272,9 @@ func (t *Template) Exec(writer io.Writer, context interface{}) (int, error) {
 			fmt.Fprintf(&errWriter, "%d\t%s\n", i, scnr.Text())
 			i++
 		}
+		if err := scnr.Err(); err != nil {
+			return 0, errors.Wrap(err, "unable to scan source")
+		}
 
 		return 0, errors.Wrapf(err, "error during execution of\n%s", errWriter.String())
 	}

--- a/template.go
+++ b/template.go
@@ -266,10 +266,10 @@ func (t *Template) Exec(writer io.Writer, context interface{}) (int, error) {
 	n, err := t.execCode(buf.String(), writer, context)
 	if err != nil {
 		var errWriter strings.Builder
-		scanner := bufio.NewScanner(&buf)
+		scnr := bufio.NewScanner(&buf)
 		i := 1
-		for scanner.Scan() {
-			fmt.Fprintf(&errWriter, "%d\t%s\n", i, scanner.Text())
+		for scnr.Scan() {
+			fmt.Fprintf(&errWriter, "%d\t%s\n", i, scnr.Text())
 			i++
 		}
 

--- a/template_test.go
+++ b/template_test.go
@@ -46,7 +46,7 @@ func TestExec(t *testing.T) {
 			nil,
 			`<$ Hello $>`,
 			"",
-			`1:29: undefined: Hello`,
+			"error during execution of\n1\t Hello \n: 1:29: undefined: Hello",
 		},
 		{
 			"Import",
@@ -266,7 +266,7 @@ func TestPanic(t *testing.T) {
 		MustParseString(`<$panic("Oh no")$>`)
 	var buf bytes.Buffer
 	_, err := template.Exec(&buf, nil)
-	require.EqualError(t, err, "Oh no")
+	require.EqualError(t, err, "error during execution of\n1\tpanic(\"Oh no\")\n: Oh no")
 }
 
 func TestNoStartOrEnd(t *testing.T) {

--- a/template_test.go
+++ b/template_test.go
@@ -711,4 +711,23 @@ if context.Name == "" { -$>
 		template.MustExec(&buf, Context{Name: ""})
 		require.Equal(t, "Hello Unknown", buf.String())
 	})
+
+	t.Run("multi line - html", func(t *testing.T) {
+		template := MustNew(interp.Options{}, stdlib.Symbols).
+			MustParseString(`<ul>
+<$-
+for _, name := range context.Names {
+	$><li><$ print(name) $></li><$
+}
+-$>
+</ul>`)
+
+		type Context struct {
+			Names []string
+		}
+
+		var buf bytes.Buffer
+		template.MustExec(&buf, Context{Names: []string{"Alice", "Joe"}})
+		require.Equal(t, "<ul><li>Alice</li><li>Joe</li></ul>", buf.String())
+	})
 }


### PR DESCRIPTION
## Description
> :warning: This PR introduces a (possible) breaking change

From now on it is possible to split the code part into multiple parts.
This however has one caveat: It breaks functions and implicit evaluations `<$ context.Name $>`.

However since functions are rarely used, and still can be by using variables, this change is a good push in the right direction.


Examples:
```
Hello <$ if context.Name == "" { $>Unknown<$ } else { print(context.Name) } $>
```

```
<ul>
<$-
for _, name := range context.Names {
	$><li><$ print(name) $></li><$
}
-$>
</ul>
```
