### PR TITLE
fix: ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,20 @@ jobs:
       -
         uses: actions/checkout@v3
       -
+        name: Get go.mod details
+        uses: Eun/go-mod-details@v1.0.4
+        id: go-mod-details
+      -
+        name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.go-mod-details.outputs.go_version }}
+      -
         name: lint
         continue-on-error: false
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: latest
+          version: v1.42.1
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Eun/yaegi-template
 
-go 1.14
+go 1.15
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
## Description

## Problem
ci was failing because of a newer golangci version.

## Solution
Force the usage of an older version.

## Notes
Also upgraded `go.mod` to minimum supported version.

